### PR TITLE
Add more game related commands

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,5 +1,6 @@
 .husky
 build
+configs
 coverage
 node_modules
 

--- a/src/commands/sheets.ts
+++ b/src/commands/sheets.ts
@@ -1,6 +1,8 @@
 import {
   ButtonInteraction,
   CommandInteraction,
+  Interaction,
+  InteractionCollector,
   Message,
   MessageActionRow,
   MessageButton,
@@ -8,21 +10,30 @@ import {
 } from 'discord.js';
 import { MessageButtonStyles } from 'discord.js/typings/enums';
 import { Discord, Slash, SlashOption } from 'discordx';
+import join from 'lodash/join';
+import map from 'lodash/map';
 import max from 'lodash/max';
 import min from 'lodash/min';
 import slice from 'lodash/slice';
 import truncate from 'lodash/truncate';
+import { isConstructorDeclaration } from 'typescript';
 import BggManager from '../managers/BggManager';
 import SheetManager from '../managers/SheetManager';
 import BggGame from '../models/BggGame';
+import SheetGame from '../models/SheetGame';
 
 @Discord()
 export abstract class Sheets {
-  private static _interactionGames: Map<CommandInteraction, BggGame[]> =
-    new Map();
+  private static _interactionGames: Map<
+    CommandInteraction,
+    BggGame[] | SheetGame[]
+  > = new Map();
   private static _interactionIndex: Map<CommandInteraction, number> = new Map();
 
-  static get interactionGames(): Map<CommandInteraction, BggGame[]> {
+  static get interactionGames(): Map<
+    CommandInteraction,
+    BggGame[] | SheetGame[]
+  > {
     return this._interactionGames;
   }
 
@@ -80,7 +91,7 @@ export abstract class Sheets {
     await interaction.deferReply();
 
     const results = await BggManager.findGame(game);
-    let gamesList;
+    let gamesList: BggGame[];
 
     if (results.length === 0) {
       await interaction.followUp(
@@ -96,20 +107,13 @@ export abstract class Sheets {
       ];
     }
 
-    Sheets._interactionGames.set(interaction, gamesList);
-    Sheets._interactionIndex.set(interaction, 0);
+    this.setSheetInteractionGames(gamesList, interaction);
 
-    const message = await interaction.followUp({
-      embeds: [this.getGameEmbed(interaction, gamesList.length)],
-      fetchReply: true,
-      components: [this.getActionRow(interaction)],
-    });
-
-    if (!(message instanceof Message)) {
-      throw Error('InvalidMessage instance');
-    }
-
-    const collector = message.createMessageComponentCollector();
+    const { collector } = await this.createGameInteraction(
+      interaction,
+      gamesList,
+      [this.getActionRow(interaction)]
+    );
 
     collector.on('collect', async (collectInteraction: ButtonInteraction) => {
       await collectInteraction.deferUpdate();
@@ -121,18 +125,14 @@ export abstract class Sheets {
         return null;
       }
 
-      const currentIndex = this.getCurrentIndex(interaction);
       const buttonId = collectInteraction.customId;
 
       switch (buttonId) {
         case 'previous-game':
-          Sheets._interactionIndex.set(interaction, max([0, currentIndex - 1]));
+          this.decrementSheetInteractionIndex(interaction);
           break;
         case 'next-game':
-          Sheets._interactionIndex.set(
-            interaction,
-            min([gamesList.length - 1, currentIndex + 1])
-          );
+          this.incrementSheetInteractionIndex(interaction);
           const nextGame = this.getCurrentGame(interaction);
           if (!nextGame.loaded) await BggManager.fillOutDetails(nextGame);
           break;
@@ -148,11 +148,58 @@ export abstract class Sheets {
       return null;
     });
 
-    collector.on('end', async () => {
-      if (!message.editable || message.deleted) return;
+    return null;
+  }
 
-      await message.edit({ components: [] });
+  @Slash('games', { description: 'Lists all games in the sheet.' })
+  async getGames(interaction: CommandInteraction): Promise<void> {
+    await interaction.deferReply();
+    const sheetManager = new SheetManager();
+    await sheetManager.connect();
+    const games: SheetGame[] = await sheetManager.getGames();
+
+    this.setSheetInteractionGames(games, interaction);
+
+    const { collector } = await this.createGameInteraction(interaction, games, [
+      new MessageActionRow().addComponents(
+        this.getPreviousButton(interaction),
+        this.getNextButton(interaction)
+      ),
+    ]);
+
+    collector.on('collect', async (collectInteraction: ButtonInteraction) => {
+      await collectInteraction.deferUpdate();
+
+      if (interaction.user.id !== collectInteraction.user.id) {
+        await interaction.followUp(
+          `${collectInteraction.member}, since you did not initiate this command, you cannot use it.`
+        );
+        return null;
+      }
+
+      const buttonId = collectInteraction.customId;
+
+      switch (buttonId) {
+        case 'previous-game':
+          this.decrementSheetInteractionIndex(interaction);
+          break;
+        case 'next-game':
+          this.incrementSheetInteractionIndex(interaction);
+          break;
+      }
+
+      await collectInteraction.editReply({
+        embeds: [this.getGameEmbed(interaction, games.length)],
+        components: [
+          new MessageActionRow().addComponents(
+            this.getPreviousButton(interaction),
+            this.getNextButton(interaction)
+          ),
+        ],
+      });
+      return null;
     });
+
     return null;
   }
 
@@ -174,7 +221,32 @@ export abstract class Sheets {
     await interaction.followUp(response);
   }
 
-  private getCurrentGame(interaction: CommandInteraction): BggGame {
+  private async createGameInteraction(
+    interaction: CommandInteraction,
+    list: BggGame[] | SheetGame[],
+    components: MessageActionRow[]
+  ): Promise<{
+    message: Message;
+    collector: InteractionCollector<Interaction>;
+  }> {
+    console.log(interaction, list);
+
+    const message = await interaction.followUp({
+      embeds: [this.getGameEmbed(interaction, list.length)],
+      fetchReply: true,
+      components: components,
+    });
+
+    if (!(message instanceof Message)) {
+      throw Error('InvalidMessage instance');
+    }
+
+    const collector = message.createMessageComponentCollector();
+
+    return { message, collector };
+  }
+
+  private getCurrentGame(interaction: CommandInteraction): BggGame | SheetGame {
     const currentIndex = Sheets._interactionIndex.get(interaction);
     const gamesList = Sheets._interactionGames.get(interaction);
     return gamesList[currentIndex];
@@ -238,11 +310,38 @@ export abstract class Sheets {
       .addField('Game Type', game.gameType(), true)
       .addField('Players', game.players(), true);
 
-    if (game.yearPublished)
+    game.yearPublished &&
       embed.addField('Year Published', game.yearPublished, false);
+    game.link() && embed.addField('BGG Link', game.link(), false);
 
-    embed.addField('BGG Link', game.link(), false);
     return embed;
+  }
+
+  private decrementSheetInteractionIndex(
+    interaction: CommandInteraction
+  ): void {
+    const currentIndex = this.getCurrentIndex(interaction);
+    Sheets._interactionIndex.set(interaction, max([0, currentIndex - 1]));
+  }
+
+  private incrementSheetInteractionIndex(
+    interaction: CommandInteraction
+  ): void {
+    const currentIndex = this.getCurrentIndex(interaction);
+    const list = Sheets._interactionGames.get(interaction);
+
+    Sheets._interactionIndex.set(
+      interaction,
+      min([list.length - 1, currentIndex + 1])
+    );
+  }
+
+  private setSheetInteractionGames(
+    list: BggGame[] | SheetGame[],
+    interaction: CommandInteraction
+  ) {
+    Sheets._interactionGames.set(interaction, list);
+    Sheets._interactionIndex.set(interaction, 0);
   }
 }
 

--- a/src/managers/BggManager.ts
+++ b/src/managers/BggManager.ts
@@ -10,7 +10,13 @@ export class BggManager {
   private static _parserOptions = {
     attributeNamePrefix: '',
     ignoreAttributes: false,
-    attrValueProcessor: (val) => decode(val, { isAttributeValue: true }),
+    attrValueProcessor: (val, attrName) => {
+      const processedValue = decode(val, { isAttributeValue: true });
+      if (attrName === 'id') {
+        return parseInt(processedValue);
+      }
+      return processedValue;
+    },
     tagValueProcessor: (val) => decode(val),
   };
 
@@ -20,7 +26,7 @@ export class BggManager {
     return get(parse(response.data, this._parserOptions), 'items.item');
   }
 
-  static async getGameInfoById(gameId: string): Promise<IBggGame | null> {
+  static async getGameInfoById(gameId: number): Promise<IBggGame | null> {
     try {
       const response = await axios.get(
         `https://api.geekdo.com/xmlapi2/thing?id=${gameId}&versions=1`
@@ -52,7 +58,7 @@ export class BggManager {
     }
   }
 
-  static async findGameById(gameId: string): Promise<BggGame | null> {
+  static async findGameById(gameId: number): Promise<BggGame | null> {
     const game = await BggManager.getGameInfoById(gameId);
     if (!game) return null;
 
@@ -63,8 +69,8 @@ export class BggManager {
     const gameInfo = await BggManager.getGameInfoById(game.id);
     if (!gameInfo) return null;
 
-    game.minPlayers = get(gameInfo, 'minplayers.value', '');
-    game.maxPlayers = get(gameInfo, 'maxplayers.value', '');
+    game.minPlayers = parseInt(get(gameInfo, 'minplayers.value', 0));
+    game.maxPlayers = parseInt(get(gameInfo, 'maxplayers.value', 0));
     game.thumbnail = get(gameInfo, 'thumbnail', '');
     game.loaded = true;
     return game;
@@ -75,9 +81,9 @@ export class BggManager {
       game.id,
       get(game, 'name.value', ''),
       game.type,
-      get(game, 'yearpublished.value', ''),
-      get(game, 'minplayers.value', ''),
-      get(game, 'maxplayers.value', ''),
+      parseInt(get(game, 'yearpublished.value', 0)),
+      parseInt(get(game, 'minplayers.value', 0)),
+      parseInt(get(game, 'maxplayers.value', 0)),
       get(game, 'thumbnail', ''),
       get(game, 'loaded', false)
     );

--- a/src/managers/SheetManager.ts
+++ b/src/managers/SheetManager.ts
@@ -9,10 +9,7 @@ import filter from 'lodash/filter';
 import map from 'lodash/map';
 
 export class SheetManager {
-  document: GoogleSpreadsheet;
-
-  construtor(): null {
-    this.document = null;
+  constructor(public document: GoogleSpreadsheet = null) {
     return;
   }
 
@@ -51,7 +48,7 @@ export class SheetManager {
     }
   }
 
-  async getGames(gameFilter: GameFilter): Promise<SheetGame[]> {
+  async getGames(gameFilter?: GameFilter): Promise<SheetGame[]> {
     if (!this.document) {
       return [];
     }
@@ -60,7 +57,7 @@ export class SheetManager {
     const rows: GoogleSpreadsheetRow[] = await sheet.getRows();
     let sheetGames = map(rows, (row) => SheetGame.fromSpreadsheetRow(row));
 
-    if (gameFilter.hasAny()) {
+    if (gameFilter && gameFilter.hasAny()) {
       sheetGames = filter(sheetGames, (game) => game.like(gameFilter));
     }
 

--- a/src/managers/SheetManager.ts
+++ b/src/managers/SheetManager.ts
@@ -1,7 +1,9 @@
 import {
   GoogleSpreadsheet,
+  GoogleSpreadsheetRow,
   GoogleSpreadsheetWorksheet,
 } from 'google-spreadsheet';
+import SheetGame from '../models/SheetGame';
 
 export class SheetManager {
   document: GoogleSpreadsheet;
@@ -44,6 +46,16 @@ export class SheetManager {
       console.error(err);
       return `Failed to add ${gameInfo[0]}`;
     }
+  }
+
+  async getGames(): Promise<SheetGame[]> {
+    if (!this.document) {
+      return [];
+    }
+
+    const sheet = this.getSheet();
+    const rows: GoogleSpreadsheetRow[] = await sheet.getRows();
+    return rows.map((row) => SheetGame.fromSpreadsheetRow(row));
   }
 
   getSheet(index = 0): GoogleSpreadsheetWorksheet | null {

--- a/src/managers/SheetManager.ts
+++ b/src/managers/SheetManager.ts
@@ -3,7 +3,10 @@ import {
   GoogleSpreadsheetRow,
   GoogleSpreadsheetWorksheet,
 } from 'google-spreadsheet';
+import GameFilter from '../models/GameFilter';
 import SheetGame from '../models/SheetGame';
+import filter from 'lodash/filter';
+import map from 'lodash/map';
 
 export class SheetManager {
   document: GoogleSpreadsheet;
@@ -48,14 +51,20 @@ export class SheetManager {
     }
   }
 
-  async getGames(): Promise<SheetGame[]> {
+  async getGames(gameFilter: GameFilter): Promise<SheetGame[]> {
     if (!this.document) {
       return [];
     }
 
     const sheet = this.getSheet();
     const rows: GoogleSpreadsheetRow[] = await sheet.getRows();
-    return rows.map((row) => SheetGame.fromSpreadsheetRow(row));
+    let sheetGames = map(rows, (row) => SheetGame.fromSpreadsheetRow(row));
+
+    if (gameFilter.hasAny()) {
+      sheetGames = filter(sheetGames, (game) => game.like(gameFilter));
+    }
+
+    return sheetGames;
   }
 
   getSheet(index = 0): GoogleSpreadsheetWorksheet | null {

--- a/src/models/BggGame.ts
+++ b/src/models/BggGame.ts
@@ -10,6 +10,15 @@ export interface IBggGame {
 }
 
 export class BggGame implements IBggGame {
+  public static gameType(type: string): string {
+    switch (type) {
+      case 'boardgameexpansion':
+        return 'Expansion';
+      default:
+        return 'Board Game';
+    }
+  }
+
   constructor(
     public id: string,
     public name: string,
@@ -24,12 +33,7 @@ export class BggGame implements IBggGame {
   }
 
   gameType(): string {
-    switch (this.type) {
-      case 'boardgameexpansion':
-        return 'Expansion';
-      default:
-        return 'Board Game';
-    }
+    return BggGame.gameType(this.type);
   }
 
   link(): string {

--- a/src/models/BggGame.ts
+++ b/src/models/BggGame.ts
@@ -1,10 +1,10 @@
 export interface IBggGame {
-  id: string;
+  id: number;
   name: string;
   type: string;
-  yearPublished: string;
-  minPlayers: string;
-  maxPlayers: string;
+  yearPublished: number;
+  minPlayers: number;
+  maxPlayers: number;
   thumbnail: string;
   loaded: boolean;
 }
@@ -20,12 +20,12 @@ export class BggGame implements IBggGame {
   }
 
   constructor(
-    public id: string,
+    public id: number,
     public name: string,
     public type: string,
-    public yearPublished: string,
-    public minPlayers: string,
-    public maxPlayers: string,
+    public yearPublished: number,
+    public minPlayers: number,
+    public maxPlayers: number,
     public thumbnail: string,
     public loaded: boolean = false
   ) {
@@ -42,7 +42,7 @@ export class BggGame implements IBggGame {
 
   players(): string {
     if (this.minPlayers === this.maxPlayers) {
-      return this.minPlayers;
+      return this.minPlayers.toString();
     } else {
       return `${this.minPlayers}-${this.maxPlayers}`;
     }

--- a/src/models/GameFilter.ts
+++ b/src/models/GameFilter.ts
@@ -1,0 +1,38 @@
+import some from 'lodash/some';
+
+export type TGameFilter = {
+  name?: string;
+  playerCount?: string;
+  owner?: string;
+  location?: string;
+};
+
+export interface IGameFilter {
+  name?: string;
+  playerCount?: string;
+  owner?: string;
+  location?: string;
+}
+
+export class GameFilter implements IGameFilter {
+  public name: string;
+  public playerCount: string;
+  public owner: string;
+  public location: string;
+
+  constructor(filter: TGameFilter) {
+    this.name = filter.name;
+    this.playerCount = filter.playerCount;
+    this.owner = filter.owner;
+    this.location = filter.location;
+  }
+
+  hasAny(): boolean {
+    return some(
+      [this.name, this.playerCount, this.owner, this.location],
+      (value) => !!value
+    );
+  }
+}
+
+export default GameFilter;

--- a/src/models/SheetGame.ts
+++ b/src/models/SheetGame.ts
@@ -1,0 +1,83 @@
+import { GoogleSpreadsheetRow } from 'google-spreadsheet';
+import get from 'lodash/get';
+import split from 'lodash/split';
+import BggGame from './BggGame';
+
+export interface ISheetGame {
+  name: string;
+  playerCount: string;
+  owner: string;
+  location: string;
+  bggLink: string;
+}
+
+export class SheetGame implements ISheetGame {
+  public static fromSpreadsheetRow(row: GoogleSpreadsheetRow): SheetGame {
+    return new SheetGame(
+      get(row, 'Game'),
+      get(row, 'Player Count'),
+      get(row, 'Owner'),
+      get(row, 'Location'),
+      get(row, 'BGG Link')
+    );
+  }
+
+  constructor(
+    public name: string,
+    public playerCount: string,
+    public owner: string,
+    public location: string,
+    public bggLink: string
+  ) {
+    return;
+  }
+
+  get id(): string {
+    const bggIdRegex = /.*boardgamegeek.+\/(\d+).*/i;
+    const matches = this.bggLink.match(bggIdRegex);
+
+    return get(matches, '[1]', '-1');
+  }
+
+  get loaded(): boolean {
+    return true;
+  }
+
+  get minPlayers(): string {
+    return split(this.playerCount, '-')[0];
+  }
+
+  get maxPlayers(): string {
+    const result = split(this.playerCount, '-');
+    return get(result, '[1]', get(result, '[0]', '0'));
+  }
+
+  get thumbnail(): string {
+    return '';
+  }
+
+  get type(): string {
+    const bggLinkRegex = /.*boardgamegeek.+\/(.+)\/\d+.*/i;
+    const matches = this.bggLink.match(bggLinkRegex);
+
+    return get(matches, '[1]', 'unknown');
+  }
+
+  get yearPublished(): null {
+    return null;
+  }
+
+  gameType(): string {
+    return BggGame.gameType(this.type);
+  }
+
+  link(): string {
+    return this.bggLink;
+  }
+
+  players(): string {
+    return this.playerCount;
+  }
+}
+
+export default SheetGame;

--- a/tests/helpers/googleSpreadsheetMocks.ts
+++ b/tests/helpers/googleSpreadsheetMocks.ts
@@ -1,0 +1,114 @@
+import {
+  CellFormat,
+  GoogleSpreadsheet,
+  GoogleSpreadsheetRow,
+  GoogleSpreadsheetWorksheet,
+  IterativeCalculationSetting,
+  RecalculationInterval,
+  SpreadsheetTheme,
+} from 'google-spreadsheet';
+import assign from 'lodash/assign';
+
+const googleSpreadsheetOptions = {
+  addNamedRange: jest.fn(),
+  addSheet: jest.fn(),
+  addWorksheet: jest.fn(),
+  autoRecalc: 'ONCE' as RecalculationInterval,
+  createNewSpreadsheetDocument: jest.fn(),
+  defaultFormat: {} as CellFormat,
+  defaultTheme: 'default',
+  deleteNamedRange: jest.fn(),
+  deleteSheet: jest.fn(),
+  headerRow: 1,
+  iterativeCalculationSettings: {} as IterativeCalculationSetting,
+  loadInfo: jest.fn(),
+  locale: 'en',
+  resetLocalCache: jest.fn(),
+  sheetCount: 0,
+  sheetsById: {},
+  sheetsByIndex: [],
+  sheetsByTitle: {},
+  spreadsheetId: '1',
+  spreadsheetTheme: {} as SpreadsheetTheme,
+  timeZone: 'America/Los_Angeles',
+  title: 'Test Spreadsheet',
+  updateProperties: jest.fn(),
+  useApiKey: jest.fn(),
+  useOAuth2Client: jest.fn(),
+  useRawAccessToken: jest.fn(),
+  useServiceAccountAuth: jest.fn(),
+};
+
+const googleSpreadsheetRowOptions = {
+  a1Range: 'Sheet1!A1:E1',
+  delete: jest.fn(),
+  rowIndex: 1,
+  save: jest.fn(),
+  Game: "Liar's Dice",
+  'Player Count': '1-4',
+  Owner: 'Me, Myself, & I',
+  Location: "A friend's house",
+  'BGG Link': 'https://boardgamegeek.com/boardgame/12345',
+};
+
+const googleSpreadsheetWorksheetOptions = {
+  a1SheetName: '',
+  addRow: jest.fn(),
+  addRows: jest.fn(),
+  cellStats: { nonEmpty: 0, loaded: 0, total: 0 },
+  clear: jest.fn(),
+  columnCount: 0,
+  copyToSpreadsheet: jest.fn(),
+  delete: jest.fn(),
+  getCell: jest.fn(),
+  getCellByA1: jest.fn(),
+  getRows: jest.fn(),
+  gridProperties: {},
+  headerValues: [],
+  hidden: false,
+  index: 0,
+  lastColumnLetter: 'Z',
+  loadCells: jest.fn(),
+  loadHeaderRow: jest.fn(),
+  resetLocalCache: jest.fn(),
+  resize: jest.fn(),
+  rightToLeft: false,
+  rowCount: 0,
+  saveCells: jest.fn(),
+  saveUpdatedCells: jest.fn(),
+  setGridProperties: jest.fn(),
+  setHeaderRow: jest.fn(),
+  sheetId: '1',
+  sheetType: 'GRID',
+  tabColor: { red: 0, green: 0, blue: 0, alpha: 0 },
+  title: '',
+  updateDimensionProperties: jest.fn(),
+  updateProperties: jest.fn(),
+};
+
+export const createMockGoogleSpreadsheet = (
+  options: unknown = googleSpreadsheetOptions
+): GoogleSpreadsheet =>
+  ({
+    ...assign(googleSpreadsheetOptions, options),
+  } as GoogleSpreadsheet);
+
+export const createMockGoogleSpreadsheetRow = (
+  options: unknown = googleSpreadsheetRowOptions
+): GoogleSpreadsheetRow =>
+  ({
+    ...assign(googleSpreadsheetRowOptions, options),
+  } as GoogleSpreadsheetRow);
+
+export const createMockGoogleSpreadsheetWorksheet = (
+  options: unknown = googleSpreadsheetWorksheetOptions
+): GoogleSpreadsheetWorksheet =>
+  ({
+    ...assign(googleSpreadsheetWorksheetOptions, options),
+  } as GoogleSpreadsheetWorksheet);
+
+export default {
+  createMockGoogleSpreadsheet,
+  createMockGoogleSpreadsheetRow,
+  createMockGoogleSpreadsheetWorksheet,
+};

--- a/tests/managers/BggManager.test.ts
+++ b/tests/managers/BggManager.test.ts
@@ -22,193 +22,203 @@ describe('BggManager', () => {
     expect(BggManager).toBeDefined();
   });
 
-  describe('#getGameInfoById', () => {
-    describe('when the request succeeds', () => {
-      const response = { data: loadFixture('secret_hitler_thing.xml') };
-      it('returns the json data', () => {
-        getSpy.mockImplementation(() => Promise.resolve(response));
-        expect(BggManager.getGameInfoById('188834')).resolves.toMatchSnapshot();
-        expect(getSpy).toHaveBeenCalledWith(
-          'https://api.geekdo.com/xmlapi2/thing?id=188834&versions=1'
-        );
+  describe('methods', () => {
+    describe('#getGameInfoById', () => {
+      describe('when the request succeeds', () => {
+        const response = { data: loadFixture('secret_hitler_thing.xml') };
+        it('returns the json data', () => {
+          getSpy.mockImplementationOnce(() => Promise.resolve(response));
+          expect(BggManager.getGameInfoById(188834)).resolves.toMatchSnapshot();
+          expect(getSpy).toHaveBeenCalledWith(
+            'https://api.geekdo.com/xmlapi2/thing?id=188834&versions=1'
+          );
+        });
+      });
+
+      describe('when the request fails', () => {
+        it('returns null', () => {
+          getSpy.mockImplementationOnce(() =>
+            Promise.reject('This should error')
+          );
+          expect(BggManager.getGameInfoById(-1)).resolves.toBeNull();
+          expect(getSpy).toHaveBeenCalledWith(
+            'https://api.geekdo.com/xmlapi2/thing?id=-1&versions=1'
+          );
+        });
       });
     });
 
-    describe('when the request fails', () => {
-      it('returns null', () => {
-        getSpy.mockImplementation(() => Promise.reject('This should error'));
-        expect(BggManager.getGameInfoById('-1')).resolves.toBeNull();
-        expect(getSpy).toHaveBeenCalledWith(
-          'https://api.geekdo.com/xmlapi2/thing?id=-1&versions=1'
-        );
+    describe('#findGame', () => {
+      describe('when the request succeeds with multiple results', () => {
+        const response = { data: loadFixture('secret_hitler_search.xml') };
+        const expectedGames = [
+          new BggGame(
+            188834,
+            'Secret Hitler',
+            'boardgame',
+            2016,
+            0,
+            0,
+            '',
+            false
+          ),
+          new BggGame(
+            77057,
+            "Hitler's Revival: Top Secret",
+            'videogame',
+            0,
+            0,
+            0,
+            '',
+            false
+          ),
+        ];
+
+        it('returns BggGame[]', () => {
+          getSpy.mockImplementationOnce(() => Promise.resolve(response));
+          expect(BggManager.findGame('secret hitler')).resolves.toEqual(
+            expectedGames
+          );
+          expect(getSpy).toHaveBeenCalledWith(
+            'https://api.geekdo.com/xmlapi2/search?query=secret hitler'
+          );
+        });
+      });
+
+      describe('when the request succeeds with only one result', () => {
+        const response = { data: loadFixture('only_one_search_result.xml') };
+        const expectedGames = [
+          new BggGame(
+            188834,
+            'Secret Hitler',
+            'boardgame',
+            2016,
+            0,
+            0,
+            '',
+            false
+          ),
+        ];
+
+        it('returns BggGame[]', () => {
+          getSpy.mockImplementationOnce(() => Promise.resolve(response));
+          expect(BggManager.findGame('secret hitler')).resolves.toEqual(
+            expectedGames
+          );
+          expect(getSpy).toHaveBeenCalledWith(
+            'https://api.geekdo.com/xmlapi2/search?query=secret hitler'
+          );
+        });
+      });
+
+      describe('when the request succeeds, but nothing was found', () => {
+        const response = { data: loadFixture('empty_search_results.xml') };
+        it('returns an empty BggGame[]', () => {
+          getSpy.mockImplementationOnce(() => Promise.resolve(response));
+          expect(BggManager.findGame('secret hitler')).resolves.toEqual([]);
+          expect(getSpy).toHaveBeenCalledWith(
+            'https://api.geekdo.com/xmlapi2/search?query=secret hitler'
+          );
+        });
+      });
+
+      describe('when the request fails', () => {
+        it('returns an empty BggGame[]', () => {
+          getSpy.mockImplementationOnce(() =>
+            Promise.reject('This should error')
+          );
+          expect(BggManager.findGame('secret hitler')).resolves.toEqual([]);
+          expect(getSpy).toHaveBeenCalledWith(
+            'https://api.geekdo.com/xmlapi2/search?query=secret hitler'
+          );
+        });
       });
     });
-  });
 
-  describe('#findGame', () => {
-    describe('when the request succeeds with multiple results', () => {
-      const response = { data: loadFixture('secret_hitler_search.xml') };
-      const expectedGames = [
-        new BggGame(
-          '188834',
+    describe('#findGameById', () => {
+      describe('when the request succeeds', () => {
+        const response = { data: loadFixture('secret_hitler_thing.xml') };
+        const expectedGame = new BggGame(
+          188834,
           'Secret Hitler',
           'boardgame',
-          '2016',
-          '',
-          '',
-          '',
-          false
-        ),
-        new BggGame(
-          '77057',
-          "Hitler's Revival: Top Secret",
-          'videogame',
-          '',
-          '',
-          '',
-          '',
-          false
-        ),
-      ];
+          2016,
+          5,
+          10,
+          'https://cf.geekdo-images.com/rAQ3hIXoH6xDcj41v9iqCg__thumb/img/xA2T7PiwN3Z8pwAksicoCOA1tf0=/fit-in/200x150/filters:strip_icc()/pic5164305.jpg',
+          true
+        );
 
-      it('returns BggGame[]', () => {
-        getSpy.mockImplementation(() => Promise.resolve(response));
-        expect(BggManager.findGame('secret hitler')).resolves.toEqual(
-          expectedGames
-        );
-        expect(getSpy).toHaveBeenCalledWith(
-          'https://api.geekdo.com/xmlapi2/search?query=secret hitler'
-        );
+        it('returns the json data', () => {
+          getSpy.mockImplementationOnce(() => Promise.resolve(response));
+          expect(BggManager.findGameById(188834)).resolves.toEqual(
+            expectedGame
+          );
+          expect(getSpy).toHaveBeenCalledWith(
+            'https://api.geekdo.com/xmlapi2/thing?id=188834&versions=1'
+          );
+        });
+      });
+
+      describe('when the request fails', () => {
+        it('returns null', () => {
+          getSpy.mockImplementationOnce(() =>
+            Promise.reject('This should error')
+          );
+          expect(BggManager.findGameById(-1)).resolves.toBeNull();
+          expect(getSpy).toHaveBeenCalledWith(
+            'https://api.geekdo.com/xmlapi2/thing?id=-1&versions=1'
+          );
+        });
       });
     });
 
-    describe('when the request succeeds with only one result', () => {
-      const response = { data: loadFixture('only_one_search_result.xml') };
-      const expectedGames = [
-        new BggGame(
-          '188834',
+    describe('#fillOutDetails', () => {
+      const initalGame = new BggGame(
+        188834,
+        'Secret Hitler',
+        'boardgame',
+        2016,
+        0,
+        0,
+        '',
+        false
+      );
+
+      describe('when the request succeeds', () => {
+        const response = { data: loadFixture('secret_hitler_thing.xml') };
+        const expectedGame = new BggGame(
+          188834,
           'Secret Hitler',
           'boardgame',
-          '2016',
-          '',
-          '',
-          '',
-          false
-        ),
-      ];
+          2016,
+          5,
+          10,
+          'https://cf.geekdo-images.com/rAQ3hIXoH6xDcj41v9iqCg__thumb/img/xA2T7PiwN3Z8pwAksicoCOA1tf0=/fit-in/200x150/filters:strip_icc()/pic5164305.jpg',
+          true
+        );
 
-      it('returns BggGame[]', () => {
-        getSpy.mockImplementation(() => Promise.resolve(response));
-        expect(BggManager.findGame('secret hitler')).resolves.toEqual(
-          expectedGames
-        );
-        expect(getSpy).toHaveBeenCalledWith(
-          'https://api.geekdo.com/xmlapi2/search?query=secret hitler'
-        );
+        it('returns a game with the information filled out', () => {
+          getSpy.mockImplementationOnce(() => Promise.resolve(response));
+          expect(BggManager.fillOutDetails(initalGame)).resolves.toEqual(
+            expectedGame
+          );
+          expect(getSpy).toHaveBeenCalledWith(
+            'https://api.geekdo.com/xmlapi2/thing?id=188834&versions=1'
+          );
+        });
       });
-    });
 
-    describe('when the request succeeds, but nothing was found', () => {
-      const response = { data: loadFixture('empty_search_results.xml') };
-      it('returns an empty BggGame[]', () => {
-        getSpy.mockImplementation(() => Promise.resolve(response));
-        expect(BggManager.findGame('secret hitler')).resolves.toEqual([]);
-        expect(getSpy).toHaveBeenCalledWith(
-          'https://api.geekdo.com/xmlapi2/search?query=secret hitler'
-        );
-      });
-    });
-
-    describe('when the request fails', () => {
-      it('returns an empty BggGame[]', () => {
-        getSpy.mockImplementation(() => Promise.reject('This should error'));
-        expect(BggManager.findGame('secret hitler')).resolves.toEqual([]);
-        expect(getSpy).toHaveBeenCalledWith(
-          'https://api.geekdo.com/xmlapi2/search?query=secret hitler'
-        );
-      });
-    });
-  });
-
-  describe('#findGameById', () => {
-    describe('when the request succeeds', () => {
-      const response = { data: loadFixture('secret_hitler_thing.xml') };
-      const expectedGame = new BggGame(
-        '188834',
-        'Secret Hitler',
-        'boardgame',
-        '2016',
-        '5',
-        '10',
-        'https://cf.geekdo-images.com/rAQ3hIXoH6xDcj41v9iqCg__thumb/img/xA2T7PiwN3Z8pwAksicoCOA1tf0=/fit-in/200x150/filters:strip_icc()/pic5164305.jpg',
-        true
-      );
-
-      it('returns the json data', () => {
-        getSpy.mockImplementation(() => Promise.resolve(response));
-        expect(BggManager.findGameById('188834')).resolves.toEqual(
-          expectedGame
-        );
-        expect(getSpy).toHaveBeenCalledWith(
-          'https://api.geekdo.com/xmlapi2/thing?id=188834&versions=1'
-        );
-      });
-    });
-
-    describe('when the request fails', () => {
-      it('returns null', () => {
-        getSpy.mockImplementation(() => Promise.reject('This should error'));
-        expect(BggManager.findGameById('-1')).resolves.toBeNull();
-        expect(getSpy).toHaveBeenCalledWith(
-          'https://api.geekdo.com/xmlapi2/thing?id=-1&versions=1'
-        );
-      });
-    });
-  });
-
-  describe('#fillOutDetails', () => {
-    const initalGame = new BggGame(
-      '188834',
-      'Secret Hitler',
-      'boardgame',
-      '2016',
-      '',
-      '',
-      '',
-      false
-    );
-
-    describe('when the request succeeds', () => {
-      const response = { data: loadFixture('secret_hitler_thing.xml') };
-      const expectedGame = new BggGame(
-        '188834',
-        'Secret Hitler',
-        'boardgame',
-        '2016',
-        '5',
-        '10',
-        'https://cf.geekdo-images.com/rAQ3hIXoH6xDcj41v9iqCg__thumb/img/xA2T7PiwN3Z8pwAksicoCOA1tf0=/fit-in/200x150/filters:strip_icc()/pic5164305.jpg',
-        true
-      );
-
-      it('returns a game with the information filled out', () => {
-        getSpy.mockImplementation(() => Promise.resolve(response));
-        expect(BggManager.fillOutDetails(initalGame)).resolves.toEqual(
-          expectedGame
-        );
-        expect(getSpy).toHaveBeenCalledWith(
-          'https://api.geekdo.com/xmlapi2/thing?id=188834&versions=1'
-        );
-      });
-    });
-
-    describe('when the request fails', () => {
-      it('returns null', () => {
-        getSpy.mockImplementation(() => Promise.reject('This should error'));
-        expect(BggManager.fillOutDetails(initalGame)).resolves.toBeNull();
-        expect(getSpy).toHaveBeenCalledWith(
-          'https://api.geekdo.com/xmlapi2/thing?id=188834&versions=1'
-        );
+      describe('when the request fails', () => {
+        it('returns null', () => {
+          getSpy.mockImplementationOnce(() =>
+            Promise.reject('This should error')
+          );
+          expect(BggManager.fillOutDetails(initalGame)).resolves.toBeNull();
+          expect(getSpy).toHaveBeenCalledWith(
+            'https://api.geekdo.com/xmlapi2/thing?id=188834&versions=1'
+          );
+        });
       });
     });
   });

--- a/tests/managers/SheetManager.test.ts
+++ b/tests/managers/SheetManager.test.ts
@@ -1,0 +1,198 @@
+import {
+  createMockGoogleSpreadsheet,
+  createMockGoogleSpreadsheetRow,
+  createMockGoogleSpreadsheetWorksheet,
+} from '../helpers/googleSpreadsheetMocks';
+import SheetManager from '../../src/managers/SheetManager';
+import GameFilter from '../../src/models/GameFilter';
+import SheetGame from '../../src/models/SheetGame';
+
+// This silences the console logging
+console.log = jest.fn();
+console.error = jest.fn();
+
+const mockProcessExit = jest.fn() as never;
+process.exit = mockProcessExit;
+
+const mockUseServiceAccountAuth = jest.fn();
+const mockLoadInfo = jest.fn();
+jest.mock('google-spreadsheet', () => ({
+  GoogleSpreadsheet: jest.fn(() =>
+    createMockGoogleSpreadsheet({
+      loadInfo: mockLoadInfo,
+      useServiceAccountAuth: mockUseServiceAccountAuth,
+    })
+  ),
+}));
+
+beforeEach(jest.clearAllMocks);
+afterAll(jest.resetAllMocks);
+
+describe('SheetManager', () => {
+  it('should be defined', () => {
+    expect(SheetManager).toBeDefined();
+  });
+
+  it('should be able to create a new SheetManager instance', () => {
+    const sheetManager = new SheetManager();
+    expect(sheetManager).toBeTruthy();
+    expect(sheetManager.document).toBe(null);
+  });
+
+  describe('methods', () => {
+    describe('#connect', () => {
+      it('should auth and load the info', async () => {
+        const sheetManager = new SheetManager();
+        await sheetManager.connect();
+
+        expect(mockUseServiceAccountAuth).toHaveBeenCalled();
+        expect(mockLoadInfo).toHaveBeenCalled();
+      });
+
+      describe('when the useServiceAccountAuth fails', () => {
+        it('should throw an error', async () => {
+          mockUseServiceAccountAuth.mockImplementation(() =>
+            Promise.reject('Test error')
+          );
+          const sheetManager = new SheetManager();
+          await sheetManager.connect();
+
+          expect(console.error).toHaveBeenCalledWith('Test error');
+          expect(mockProcessExit).toHaveBeenCalledWith(1);
+        });
+      });
+
+      describe('when the loadInfo fails', () => {
+        it('should throw an error', async () => {
+          mockLoadInfo.mockImplementation(() => Promise.reject('Test error'));
+          const sheetManager = new SheetManager();
+          await sheetManager.connect();
+
+          expect(console.error).toHaveBeenCalledWith('Test error');
+          expect(mockProcessExit).toHaveBeenCalledWith(1);
+        });
+      });
+    });
+
+    describe('#addGame', () => {
+      const gameInfo = [
+        "Liar's Dice",
+        '1-4',
+        'Me, Myself, & I',
+        "A friend's house",
+        'https://www.boardgamegeek.com/boardgame/12345',
+      ];
+      const mockSheet = createMockGoogleSpreadsheetWorksheet({
+        addRow: jest.fn(() =>
+          Promise.resolve(createMockGoogleSpreadsheetRow())
+        ),
+      });
+
+      it('should add a new game to the sheet', async () => {
+        const sheetManager = new SheetManager();
+        sheetManager.document = createMockGoogleSpreadsheet({
+          sheetsByIndex: [mockSheet],
+        });
+        const response = await sheetManager.addGame(gameInfo);
+
+        expect(mockSheet.addRow).toHaveBeenCalledWith(gameInfo);
+        expect(response).toBe(`Successfully added ${gameInfo[0]}`);
+      });
+
+      describe('when the addRow operation fails', () => {
+        const mockSheet = createMockGoogleSpreadsheetWorksheet({
+          addRow: jest.fn(() => Promise.reject('Test error')),
+        });
+
+        it('should throw an error', async () => {
+          const sheetManager = new SheetManager();
+          sheetManager.document = createMockGoogleSpreadsheet({
+            sheetsByIndex: [mockSheet],
+          });
+          const response = await sheetManager.addGame(gameInfo);
+
+          expect(mockSheet.addRow).toHaveBeenCalledWith(gameInfo);
+          expect(console.error).toHaveBeenCalledWith('Test error');
+          expect(response).toBe(`Failed to add ${gameInfo[0]}`);
+        });
+      });
+
+      describe('when not the document has not been set', () => {
+        it('should return an empty string', async () => {
+          const sheetManager = new SheetManager();
+          const response = await sheetManager.addGame(gameInfo);
+          expect(response).toBe('');
+        });
+      });
+    });
+
+    describe('#getGames', () => {
+      const mockSheet = createMockGoogleSpreadsheetWorksheet({
+        getRows: jest.fn(() => [createMockGoogleSpreadsheetRow()]),
+      });
+
+      it('should return an array of SheetGames', async () => {
+        const sheetManager = new SheetManager();
+        sheetManager.document = createMockGoogleSpreadsheet({
+          sheetsByIndex: [mockSheet],
+        });
+
+        const [response] = await sheetManager.getGames();
+        expect(response).toBeInstanceOf(SheetGame);
+        expect(response.name).toBe("Liar's Dice");
+        expect(response.playerCount).toBe('1-4');
+        expect(response.owner).toBe('Me, Myself, & I');
+        expect(response.location).toBe("A friend's house");
+        expect(response.bggLink).toBe(
+          'https://boardgamegeek.com/boardgame/12345'
+        );
+      });
+
+      describe('when a gameFilter is passed', () => {
+        const gameFilter = new GameFilter({
+          name: 'secret',
+        });
+
+        it('should filter the games', async () => {
+          const sheetManager = new SheetManager();
+          sheetManager.document = createMockGoogleSpreadsheet({
+            sheetsByIndex: [mockSheet],
+          });
+
+          const response = await sheetManager.getGames(gameFilter);
+          expect(response.length).toBe(0);
+        });
+      });
+
+      describe('when not the document has not been set', () => {
+        it('should return an empty array', async () => {
+          const sheetManager = new SheetManager();
+          const response = await sheetManager.getGames();
+
+          expect(response).toBeInstanceOf(Array);
+          expect(response.length).toBe(0);
+        });
+      });
+    });
+
+    describe('#getSheet', () => {
+      const mockSheet = createMockGoogleSpreadsheetWorksheet();
+
+      it('should return the GoogleSpreadsheetWorksheet from an index', () => {
+        const sheetManager = new SheetManager();
+        sheetManager.document = createMockGoogleSpreadsheet({
+          sheetsByIndex: [mockSheet],
+        });
+
+        expect(sheetManager.getSheet(0)).toBe(mockSheet);
+      });
+
+      describe('when not the document has not been set', () => {
+        it('should return null', () => {
+          const sheetManager = new SheetManager();
+          expect(sheetManager.getSheet(0)).toBe(null);
+        });
+      });
+    });
+  });
+});

--- a/tests/managers/__snapshots__/BggManager.test.ts.snap
+++ b/tests/managers/__snapshots__/BggManager.test.ts.snap
@@ -1,113 +1,113 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`BggManager #getGameInfoById when the request succeeds returns the json data 1`] = `
+exports[`BggManager methods #getGameInfoById when the request succeeds returns the json data 1`] = `
 Object {
   "description": "Secret Hitler is a dramatic game of political intrigue and betrayal set in 1930s Germany. Each player is randomly and secretly assigned to be a liberal or a fascist, and one player is Secret Hitler. The fascists coordinate to sow distrust and install their cold-blooded leader; the liberals must find and stop the Secret Hitler before it's too late. The liberal team always has a majority.&#10;&#10;At the beginning of the game, players close their eyes, and the fascists reveal themselves to one another. Secret Hitler keeps his eyes closed, but puts his thumb up so the fascists can see who he is. The fascists learn who Hitler is, but Hitler doesn't know who his fellow fascists are, and the liberals don't know who anyone is.&#10;&#10;Each round, players elect a President and a Chancellor who will work together to enact a law from a random deck. If the government passes a fascist law, players must try to figure out if they were betrayed or simply unlucky. Secret Hitler also features government powers that come into play as fascism advances. The fascists will use those powers to create chaos unless liberals can pull the nation back from the brink of war.&#10;&#10;The objective of the liberal team is to pass five liberal policies or assassinate Secret Hitler. The objective of the fascist team is to pass six fascist policies or elect Secret Hitler chancellor after three fascist policies have passed.&#10;&#10;",
-  "id": "188834",
+  "id": 188834,
   "image": "https://cf.geekdo-images.com/rAQ3hIXoH6xDcj41v9iqCg__original/img/7oKwNUYakx3-vHUBLHWVuFNKfl4=/0x0/filters:format(jpeg)/pic5164305.jpg",
   "link": Array [
     Object {
-      "id": "1023",
+      "id": 1023,
       "type": "boardgamecategory",
       "value": "Bluffing",
     },
     Object {
-      "id": "1002",
+      "id": 1002,
       "type": "boardgamecategory",
       "value": "Card Game",
     },
     Object {
-      "id": "1039",
+      "id": 1039,
       "type": "boardgamecategory",
       "value": "Deduction",
     },
     Object {
-      "id": "1079",
+      "id": 1079,
       "type": "boardgamecategory",
       "value": "Humor",
     },
     Object {
-      "id": "1030",
+      "id": 1030,
       "type": "boardgamecategory",
       "value": "Party Game",
     },
     Object {
-      "id": "1001",
+      "id": 1001,
       "type": "boardgamecategory",
       "value": "Political",
     },
     Object {
-      "id": "1120",
+      "id": 1120,
       "type": "boardgamecategory",
       "value": "Print & Play",
     },
     Object {
-      "id": "2891",
+      "id": 2891,
       "type": "boardgamemechanic",
       "value": "Hidden Roles",
     },
     Object {
-      "id": "2685",
+      "id": 2685,
       "type": "boardgamemechanic",
       "value": "Player Elimination",
     },
     Object {
-      "id": "2019",
+      "id": 2019,
       "type": "boardgamemechanic",
       "value": "Team-Based Game",
     },
     Object {
-      "id": "2814",
+      "id": 2814,
       "type": "boardgamemechanic",
       "value": "Traitor Game",
     },
     Object {
-      "id": "2017",
+      "id": 2017,
       "type": "boardgamemechanic",
       "value": "Voting",
     },
     Object {
-      "id": "8374",
+      "id": 8374,
       "type": "boardgamefamily",
       "value": "Crowdfunding: Kickstarter",
     },
     Object {
-      "id": "70948",
+      "id": 70948,
       "type": "boardgamefamily",
       "value": "Digital Implementations: Tabletopia",
     },
     Object {
-      "id": "2989",
+      "id": 2989,
       "type": "boardgamefamily",
       "value": "Game: Werewolf / Mafia",
     },
     Object {
-      "id": "87375",
+      "id": 87375,
       "type": "boardgamedesigner",
       "value": "Mike Boxleiter",
     },
     Object {
-      "id": "87376",
+      "id": 87376,
       "type": "boardgamedesigner",
       "value": "Tommy Maranges",
     },
     Object {
-      "id": "75735",
+      "id": 75735,
       "type": "boardgameartist",
       "value": "Mackenzie Schubert",
     },
     Object {
-      "id": "34112",
+      "id": 34112,
       "type": "boardgamepublisher",
       "value": "Goat Wolf & Cabbage",
     },
     Object {
-      "id": "4",
+      "id": 4,
       "type": "boardgamepublisher",
       "value": "(Self-Published)",
     },
     Object {
-      "id": "14966",
+      "id": 14966,
       "type": "boardgamepublisher",
       "value": "Print & Play Productions",
     },
@@ -430,30 +430,30 @@ Object {
         "depth": Object {
           "value": "2.125",
         },
-        "id": "292643",
+        "id": 292643,
         "image": "https://cf.geekdo-images.com/Kbs6vVX1HNPGd7PEq1SEYw__original/img/wCoXaLIA_OVhuC01PNcrqw2KOU8=/0x0/filters:format(png)/pic2771488.png",
         "length": Object {
           "value": "15",
         },
         "link": Array [
           Object {
-            "id": "188834",
+            "id": 188834,
             "inbound": "true",
             "type": "boardgameversion",
             "value": "Secret Hitler",
           },
           Object {
-            "id": "34112",
+            "id": 34112,
             "type": "boardgamepublisher",
             "value": "Goat Wolf & Cabbage",
           },
           Object {
-            "id": "75735",
+            "id": 75735,
             "type": "boardgameartist",
             "value": "Mackenzie Schubert",
           },
           Object {
-            "id": "2184",
+            "id": 2184,
             "type": "language",
             "value": "English",
           },
@@ -482,30 +482,30 @@ Object {
         "depth": Object {
           "value": "1.9685",
         },
-        "id": "363714",
+        "id": 363714,
         "image": "https://cf.geekdo-images.com/DHPsGchaEUIgmvE70ARnsQ__original/img/PQ_MN7-XoObUDax_1W6Nc36cm5A=/0x0/filters:format(jpeg)/pic5164299.jpg",
         "length": Object {
           "value": "14.9606",
         },
         "link": Array [
           Object {
-            "id": "188834",
+            "id": 188834,
             "inbound": "true",
             "type": "boardgameversion",
             "value": "Secret Hitler",
           },
           Object {
-            "id": "34112",
+            "id": 34112,
             "type": "boardgamepublisher",
             "value": "Goat Wolf & Cabbage",
           },
           Object {
-            "id": "75735",
+            "id": 75735,
             "type": "boardgameartist",
             "value": "Mackenzie Schubert",
           },
           Object {
-            "id": "2184",
+            "id": 2184,
             "type": "language",
             "value": "English",
           },
@@ -534,25 +534,25 @@ Object {
         "depth": Object {
           "value": "0",
         },
-        "id": "377298",
+        "id": 377298,
         "image": "https://cf.geekdo-images.com/Kbs6vVX1HNPGd7PEq1SEYw__original/img/wCoXaLIA_OVhuC01PNcrqw2KOU8=/0x0/filters:format(png)/pic2771488.png",
         "length": Object {
           "value": "0",
         },
         "link": Array [
           Object {
-            "id": "188834",
+            "id": 188834,
             "inbound": "true",
             "type": "boardgameversion",
             "value": "Secret Hitler",
           },
           Object {
-            "id": "14966",
+            "id": 14966,
             "type": "boardgamepublisher",
             "value": "Print & Play Productions",
           },
           Object {
-            "id": "2199",
+            "id": 2199,
             "type": "language",
             "value": "Polish",
           },
@@ -581,35 +581,35 @@ Object {
         "depth": Object {
           "value": "0",
         },
-        "id": "301129",
+        "id": 301129,
         "image": "https://cf.geekdo-images.com/Kbs6vVX1HNPGd7PEq1SEYw__original/img/wCoXaLIA_OVhuC01PNcrqw2KOU8=/0x0/filters:format(png)/pic2771488.png",
         "length": Object {
           "value": "0",
         },
         "link": Array [
           Object {
-            "id": "188834",
+            "id": 188834,
             "inbound": "true",
             "type": "boardgameversion",
             "value": "Secret Hitler",
           },
           Object {
-            "id": "4",
+            "id": 4,
             "type": "boardgamepublisher",
             "value": "(Self-Published)",
           },
           Object {
-            "id": "34112",
+            "id": 34112,
             "type": "boardgamepublisher",
             "value": "Goat Wolf & Cabbage",
           },
           Object {
-            "id": "30025",
+            "id": 30025,
             "type": "boardgamepublisher",
             "value": "Rattlebox Games",
           },
           Object {
-            "id": "2184",
+            "id": 2184,
             "type": "language",
             "value": "English",
           },

--- a/tests/models/BggGame.test.ts
+++ b/tests/models/BggGame.test.ts
@@ -1,87 +1,51 @@
 import BggGame from '../../src/models/BggGame';
 
 describe('BggGame', () => {
+  const game = new BggGame(1, 'name', 'boardgame', 1970, 1, 5, 'thumbnail');
+
   it('should create an instance', () => {
-    expect(
-      new BggGame(
-        '1',
-        'name',
-        'type',
-        'yearPublished',
-        'minPlayers',
-        'maxPlayers',
-        'thumbnail'
-      )
-    ).toBeTruthy();
+    expect(game).toBeTruthy();
   });
 
-  describe('#gameType', () => {
-    const game = new BggGame(
-      '1',
-      'name',
-      'boardgame',
-      'yearPublished',
-      'minPlayers',
-      'maxPlayers',
-      'thumbnail'
-    );
+  describe('methods', () => {
+    describe('#gameType', () => {
+      it('should return `Board Game` by default', () => {
+        expect(game.gameType()).toBe('Board Game');
+      });
 
-    it('should return `Board Game` by default', () => {
-      expect(game.gameType()).toBe('Board Game');
-    });
-
-    describe('when the type is an expansion', () => {
-      it('should return the game type as a pretty string', () => {
-        game.type = 'boardgameexpansion';
-        expect(game.gameType()).toEqual('Expansion');
+      describe('when the type is an expansion', () => {
+        it('should return the game type as a pretty string', () => {
+          const game = new BggGame(
+            1,
+            'name',
+            'boardgameexpansion',
+            1970,
+            1,
+            5,
+            'thumbnail'
+          );
+          expect(game.gameType()).toEqual('Expansion');
+        });
       });
     });
-  });
 
-  describe('#link', () => {
-    it('should return a link to the game', () => {
-      const game = new BggGame(
-        '1',
-        'name',
-        'boardgame',
-        'yearPublished',
-        'minPlayers',
-        'maxPlayers',
-        'thumbnail'
-      );
-
-      expect(game.link()).toEqual('https://boardgamegeek.com/boardgame/1');
-    });
-  });
-
-  describe('#players', () => {
-    it('should return a string with the number of players', () => {
-      const game = new BggGame(
-        '1',
-        'name',
-        'boardgame',
-        'yearPublished',
-        '1',
-        '5',
-        'thumbnail'
-      );
-
-      expect(game.players()).toEqual('1-5');
+    describe('#link', () => {
+      it('should return a link to the game', () => {
+        expect(game.link()).toEqual('https://boardgamegeek.com/boardgame/1');
+      });
     });
 
-    describe('when minPlayers and maxPlayers are the same', () => {
+    describe('#players', () => {
       it('should return a string with the number of players', () => {
-        const game = new BggGame(
-          '1',
-          'name',
-          'boardgame',
-          'yearPublished',
-          '2',
-          '2',
-          'thumbnail'
-        );
+        expect(game.players()).toEqual('1-5');
+      });
 
-        expect(game.players()).toEqual('2');
+      describe('when minPlayers and maxPlayers are the same', () => {
+        it('should return a string with the number of players', () => {
+          const game = new BggGame(1, 'name', 'type', 1970, 2, 2, 'thumbnail');
+
+          expect(game.players()).toEqual('2');
+        });
       });
     });
   });

--- a/tests/models/BggGame.test.ts
+++ b/tests/models/BggGame.test.ts
@@ -7,6 +7,20 @@ describe('BggGame', () => {
     expect(game).toBeTruthy();
   });
 
+  describe('static methods', () => {
+    describe('#gameType', () => {
+      it('should return `Board Game` by default', () => {
+        expect(BggGame.gameType('boardgame')).toBe('Board Game');
+      });
+
+      describe('when the type is an expansion', () => {
+        it('should return the game type as a pretty string', () => {
+          expect(BggGame.gameType('boardgameexpansion')).toEqual('Expansion');
+        });
+      });
+    });
+  });
+
   describe('methods', () => {
     describe('#gameType', () => {
       it('should return `Board Game` by default', () => {

--- a/tests/models/GameFilter.test.ts
+++ b/tests/models/GameFilter.test.ts
@@ -3,6 +3,9 @@ import GameFilter from '../../src/models/GameFilter';
 describe('GameFilter', () => {
   const gameFilter = new GameFilter({
     name: 'Name filter',
+    playerCount: '2',
+    owner: 'Me',
+    location: 'My house',
   });
 
   it('should create an instance', () => {

--- a/tests/models/GameFilter.test.ts
+++ b/tests/models/GameFilter.test.ts
@@ -1,0 +1,24 @@
+import GameFilter from '../../src/models/GameFilter';
+
+describe('GameFilter', () => {
+  const gameFilter = new GameFilter({
+    name: 'Name filter',
+  });
+
+  it('should create an instance', () => {
+    expect(gameFilter).toBeTruthy();
+  });
+
+  describe('methods', () => {
+    describe('#hasAny', () => {
+      it('should return true if any of the filters are defined', () => {
+        expect(gameFilter.hasAny()).toBe(true);
+      });
+
+      it('should return false if none of the filters are defined', () => {
+        const gameFilter = new GameFilter({});
+        expect(gameFilter.hasAny()).toBe(false);
+      });
+    });
+  });
+});

--- a/tests/models/SheetGame.test.ts
+++ b/tests/models/SheetGame.test.ts
@@ -1,0 +1,80 @@
+import BggGame from '../../src/models/BggGame';
+import SheetGame from '../../src/models/SheetGame';
+
+describe('SheetGame', () => {
+  const sheetGame = new SheetGame(
+    'name',
+    '1-4',
+    'Me, Myself, & I',
+    "A friend's house",
+    'https://boardgamegeek.com/boardgame/1'
+  );
+
+  it('should create an instance', () => {
+    expect(sheetGame).toBeTruthy();
+  });
+
+  describe('getters', () => {
+    describe('.id', () => {
+      it('should return the id', () => {
+        expect(sheetGame.id).toBe('1');
+      });
+    });
+
+    describe('.loaded', () => {
+      it('should return loaded', () => {
+        expect(sheetGame.loaded).toBe(true);
+      });
+    });
+
+    describe('.minPlayers', () => {
+      it('should return loaded', () => {
+        expect(sheetGame.minPlayers).toBe('1');
+      });
+    });
+
+    describe('.maxPlayers', () => {
+      it('should return loaded', () => {
+        expect(sheetGame.maxPlayers).toBe('4');
+      });
+    });
+
+    describe('.thumbnail', () => {
+      it('should return loaded', () => {
+        expect(sheetGame.thumbnail).toBe('');
+      });
+    });
+
+    describe('.type', () => {
+      it('should return loaded', () => {
+        expect(sheetGame.type).toBe('boardgame');
+      });
+    });
+
+    describe('.yearPublished', () => {
+      it('should return loaded', () => {
+        expect(sheetGame.yearPublished).toBe(null);
+      });
+    });
+  });
+
+  describe('methods', () => {
+    describe('#gameType', () => {
+      it('should return the game type', () => {
+        expect(sheetGame.gameType()).toBe(BggGame.gameType(sheetGame.type));
+      });
+    });
+
+    describe('#link', () => {
+      it('should return the link', () => {
+        expect(sheetGame.link()).toBe(sheetGame.bggLink);
+      });
+    });
+
+    describe('#players', () => {
+      it('should return the players', () => {
+        expect(sheetGame.players()).toBe(sheetGame.playerCount);
+      });
+    });
+  });
+});

--- a/tests/models/SheetGame.test.ts
+++ b/tests/models/SheetGame.test.ts
@@ -1,3 +1,4 @@
+import { GoogleSpreadsheetRow } from 'google-spreadsheet';
 import BggGame from '../../src/models/BggGame';
 import GameFilter from '../../src/models/GameFilter';
 import SheetGame from '../../src/models/SheetGame';
@@ -13,6 +14,34 @@ describe('SheetGame', () => {
 
   it('should create an instance', () => {
     expect(sheetGame).toBeTruthy();
+  });
+
+  describe('static methods', () => {
+    describe('#fromSpreadsheetRow', () => {
+      const row: GoogleSpreadsheetRow = {
+        rowIndex: 1,
+        a1Range: 'Sheet1!A1:E1',
+        save: jest.fn(),
+        delete: jest.fn(),
+        Game: 'name',
+        'Player Count': '1-4',
+        Owner: 'Me, Myself, & I',
+        Location: "A friend's house",
+        'BGG Link': 'https://boardgamegeek.com/boardgame/1',
+      };
+
+      it('should create a SheetGame from a spreadsheet row', () => {
+        const sheetGame = SheetGame.fromSpreadsheetRow(row);
+        expect(sheetGame).toBeTruthy();
+        expect(sheetGame.name).toEqual('name');
+        expect(sheetGame.playerCount).toEqual('1-4');
+        expect(sheetGame.owner).toEqual('Me, Myself, & I');
+        expect(sheetGame.location).toEqual("A friend's house");
+        expect(sheetGame.bggLink).toEqual(
+          'https://boardgamegeek.com/boardgame/1'
+        );
+      });
+    });
   });
 
   describe('getters', () => {
@@ -85,6 +114,10 @@ describe('SheetGame', () => {
         });
 
         it('returns true', () => {
+          expect(game.like(new GameFilter({ playerCount: '1-3' }))).toBe(true);
+        });
+
+        it('returns true', () => {
           expect(game.like(new GameFilter({ owner: 'myself' }))).toBe(true);
         });
 
@@ -100,6 +133,10 @@ describe('SheetGame', () => {
 
         it('returns false', () => {
           expect(game.like(new GameFilter({ playerCount: '5' }))).toBe(false);
+        });
+
+        it('returns false', () => {
+          expect(game.like(new GameFilter({ playerCount: '5-8' }))).toBe(false);
         });
 
         it('returns false', () => {

--- a/tests/models/SheetGame.test.ts
+++ b/tests/models/SheetGame.test.ts
@@ -1,4 +1,5 @@
 import BggGame from '../../src/models/BggGame';
+import GameFilter from '../../src/models/GameFilter';
 import SheetGame from '../../src/models/SheetGame';
 
 describe('SheetGame', () => {
@@ -17,7 +18,7 @@ describe('SheetGame', () => {
   describe('getters', () => {
     describe('.id', () => {
       it('should return the id', () => {
-        expect(sheetGame.id).toBe('1');
+        expect(sheetGame.id).toBe(1);
       });
     });
 
@@ -28,31 +29,31 @@ describe('SheetGame', () => {
     });
 
     describe('.minPlayers', () => {
-      it('should return loaded', () => {
-        expect(sheetGame.minPlayers).toBe('1');
+      it('should return min players as an int', () => {
+        expect(sheetGame.minPlayers).toBe(1);
       });
     });
 
     describe('.maxPlayers', () => {
-      it('should return loaded', () => {
-        expect(sheetGame.maxPlayers).toBe('4');
+      it('should return max players as an int', () => {
+        expect(sheetGame.maxPlayers).toBe(4);
       });
     });
 
     describe('.thumbnail', () => {
-      it('should return loaded', () => {
+      it('should return the thumbnail', () => {
         expect(sheetGame.thumbnail).toBe('');
       });
     });
 
     describe('.type', () => {
-      it('should return loaded', () => {
+      it('should return the type', () => {
         expect(sheetGame.type).toBe('boardgame');
       });
     });
 
     describe('.yearPublished', () => {
-      it('should return loaded', () => {
+      it('should return the year published', () => {
         expect(sheetGame.yearPublished).toBe(null);
       });
     });
@@ -62,6 +63,52 @@ describe('SheetGame', () => {
     describe('#gameType', () => {
       it('should return the game type', () => {
         expect(sheetGame.gameType()).toBe(BggGame.gameType(sheetGame.type));
+      });
+    });
+
+    describe('#like', () => {
+      const game = new SheetGame(
+        'Teenage Mutant Ninja Turtles III: The Manhattan Project',
+        '1-4',
+        'Me, Myself, & I',
+        "A friend's house",
+        'https://boardgamegeek.com/boardgame/1'
+      );
+
+      describe('when it matches the filter', () => {
+        it('returns true', () => {
+          expect(game.like(new GameFilter({ name: 'ninja' }))).toBe(true);
+        });
+
+        it('returns true', () => {
+          expect(game.like(new GameFilter({ playerCount: '2' }))).toBe(true);
+        });
+
+        it('returns true', () => {
+          expect(game.like(new GameFilter({ owner: 'myself' }))).toBe(true);
+        });
+
+        it('returns true', () => {
+          expect(game.like(new GameFilter({ location: 'house' }))).toBe(true);
+        });
+      });
+
+      describe('when it does not match the filter', () => {
+        it('returns false', () => {
+          expect(game.like(new GameFilter({ name: 'pizaa' }))).toBe(false);
+        });
+
+        it('returns false', () => {
+          expect(game.like(new GameFilter({ playerCount: '5' }))).toBe(false);
+        });
+
+        it('returns false', () => {
+          expect(game.like(new GameFilter({ owner: 'someone' }))).toBe(false);
+        });
+
+        it('returns false', () => {
+          expect(game.like(new GameFilter({ location: 'home' }))).toBe(false);
+        });
       });
     });
 

--- a/tests/models/SheetGame.test.ts
+++ b/tests/models/SheetGame.test.ts
@@ -1,4 +1,4 @@
-import { GoogleSpreadsheetRow } from 'google-spreadsheet';
+import { createMockGoogleSpreadsheetRow } from '../helpers/googleSpreadsheetMocks';
 import BggGame from '../../src/models/BggGame';
 import GameFilter from '../../src/models/GameFilter';
 import SheetGame from '../../src/models/SheetGame';
@@ -18,27 +18,17 @@ describe('SheetGame', () => {
 
   describe('static methods', () => {
     describe('#fromSpreadsheetRow', () => {
-      const row: GoogleSpreadsheetRow = {
-        rowIndex: 1,
-        a1Range: 'Sheet1!A1:E1',
-        save: jest.fn(),
-        delete: jest.fn(),
-        Game: 'name',
-        'Player Count': '1-4',
-        Owner: 'Me, Myself, & I',
-        Location: "A friend's house",
-        'BGG Link': 'https://boardgamegeek.com/boardgame/1',
-      };
+      const row = createMockGoogleSpreadsheetRow();
 
       it('should create a SheetGame from a spreadsheet row', () => {
         const sheetGame = SheetGame.fromSpreadsheetRow(row);
         expect(sheetGame).toBeTruthy();
-        expect(sheetGame.name).toEqual('name');
+        expect(sheetGame.name).toEqual("Liar's Dice");
         expect(sheetGame.playerCount).toEqual('1-4');
         expect(sheetGame.owner).toEqual('Me, Myself, & I');
         expect(sheetGame.location).toEqual("A friend's house");
         expect(sheetGame.bggLink).toEqual(
-          'https://boardgamegeek.com/boardgame/1'
+          'https://boardgamegeek.com/boardgame/12345'
         );
       });
     });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,6 @@
     "target": "es2021"
   },
   "exclude": ["node_modules"],
-  "include": ["src"],
+  "include": ["src", "tests"],
   "indent": [true, "spaces", 2]
 }


### PR DESCRIPTION
## What
Add new commands and more coverage

## Changes
- Added the new `viewgame` command
  - allows us to search through the library sheet with optional filters on: name, player count, owner, & location
- Lots of refactors
- Repo now has 100% coverage
